### PR TITLE
Refactor and fix `SingleExam` extractor

### DIFF
--- a/src/js/utils/global.js
+++ b/src/js/utils/global.js
@@ -157,3 +157,26 @@ function createElementFromString(htmlString) {
         return prev;
     }, {});
 }
+
+/**
+ * Given a table where the first columns consists of plaintext
+ * labels/legends, it tries to find the row with a specific label and returns
+ * the entire row
+ * ```
+ * | Label1 | <whatever> |
+ * | Label2 | example    |
+ * ```
+ *
+ * @param {HTMLElement} $table The table
+ * @param {string} label The label/legend to search for
+ * @returns {HTMLElement | null} The table row that matched the search, or null
+ */
+function tableTryFindRow($table, label) {
+    const $tr = Array.from($table.querySelectorAll("tr")).find(
+        (e) => {
+            const $tdLabel = e.children[0];
+            return $tdLabel.textContent === label;
+        }
+    );
+    return $tr || null;
+}

--- a/src/test/extractors/single_exam.js
+++ b/src/test/extractors/single_exam.js
@@ -1,0 +1,89 @@
+describe("SingleExam extractor", function () {
+    describe("Normal view", function () {
+        let ev = null;
+
+        before(function () {
+            return updatejQueryContext("single_exam/normal.html").then(() => {
+                const singleExam = new SingleExam();
+                ev = singleExam.getEvent();
+            });
+        });
+
+        it("Should parse dates correctly", () => {
+            chai.assert.deepEqual(ev.from, new Date("2022-05-11 17:30"), "Start datetime");
+            chai.assert.deepEqual(ev.to, new Date("2022-05-11 19:30"), "End datetime");
+        });
+
+        it("Should parse subject correctly", () => {
+            chai.assert.equal(ev.subject.name, "Sistemas Operativos", "Course name");
+            chai.assert.equal(ev.subject.acronym, "SO", "Course acronym");
+            chai.assert.match(ev.subject.url, /ucurr_geral.ficha_uc_view\?pv_ocorrencia_id=484378$/, "Course URL");
+        });
+
+        it("Should parse type of exam correctly", () => {
+            chai.assert.equal(ev.info, "Mini-testes (2ºS)");
+        });
+
+        it("Should parse rooms correctly", () => {
+            chai.assert.isArray(ev.rooms);
+            chai.assert.lengthOf(ev.rooms, 10);
+            chai.assert.equal(ev.rooms[0].name, "B104");
+            chai.assert.match(ev.rooms[0].url, /instal_geral.espaco_view\?pv_id=73471$/);
+            chai.assert.equal(ev.rooms[5].name, "B102");
+            chai.assert.match(ev.rooms[5].url, /instal_geral.espaco_view\?pv_id=73445$/);
+            chai.assert.equal(ev.rooms[9].name, "B304");
+            chai.assert.equal(ev.roomNames, "B104, B208, B213, B105, B103, B102, B308, B307, B305, B304");
+        });
+
+        it("Should parse teachers/supervisors correctly", () => {
+            chai.assert.isArray(ev.teachers);
+            chai.assert.lengthOf(ev.teachers, 11);
+            chai.assert.equal(ev.teachers[0].name, "Rui Carlos Camacho de Sousa Ferreira da Silva");
+            chai.assert.equal(ev.teachers[3].name, "Luís Filipe Pinto de Almeida Teixeira");
+        });
+    })
+
+    describe("View with optional parameter 'Observations'", function () {
+        let ev = null;
+        before(function () {
+            return updatejQueryContext("single_exam/observations.html").then(() => {
+                const singleExam = new SingleExam();
+                ev = singleExam.getEvent();
+            });
+        });
+
+        it("Should parse correctly", function () {
+            chai.assert.equal(ev.subject.name, "Laboratório de Bases de Dados e Aplicações Web", "Course name");
+            chai.assert.equal(ev.subject.acronym, "LBAW", "Course acronym");
+            chai.assert.equal(ev.info, "Port.Est.Especiais 1ºS");
+            chai.assert.deepEqual(ev.from, new Date("2022-05-16 14:30"), "Start datetime");
+            chai.assert.deepEqual(ev.to, new Date("2022-05-16 17:30"), "End datetime");
+            chai.assert.isArray(ev.rooms);
+            chai.assert.lengthOf(ev.rooms, 1);
+            chai.assert.isArray(ev.teachers);
+            chai.assert.lengthOf(ev.teachers, 4);
+        });
+    })
+
+    describe("View with missing parameter 'Vigilantes'", function () {
+        let ev = null;
+        before(function () {
+            return updatejQueryContext("single_exam/no_supervisors.html").then(() => {
+                const singleExam = new SingleExam();
+                ev = singleExam.getEvent();
+            });
+        });
+
+        it("Should parse correctly", function () {
+            chai.assert.equal(ev.subject.name, "Desenho de Construção Mecânica", "Course name");
+            chai.assert.equal(ev.subject.acronym, "DCM", "Course acronym");
+            chai.assert.equal(ev.info, "Mini-testes (2ºS)");
+            chai.assert.deepEqual(ev.from, new Date("2022-05-16 14:30"), "Start datetime");
+            chai.assert.deepEqual(ev.to, new Date("2022-05-16 16:30"), "End datetime");
+            chai.assert.isArray(ev.rooms);
+            chai.assert.lengthOf(ev.rooms, 4);
+            chai.assert.isArray(ev.teachers);
+            chai.assert.lengthOf(ev.teachers, 0);
+        });
+    })
+})

--- a/src/test/pages/single_exam/no_supervisors.html
+++ b/src/test/pages/single_exam/no_supervisors.html
@@ -1,0 +1,66 @@
+<div id="conteudo">
+    <div id="conteudoinner">
+        <h1 id="seccao"></h1>
+        <a name="ancora-conteudo" class="ecra"></a>
+        <h1>Exame de DCM - Desenho de Construção Mecânica (L.EM008) - 2S</h1>
+        <table>
+            <tbody>
+                <tr>
+                    <td class="formulario-legenda">Código:</td>
+                    <td><a href="ucurr_geral.ficha_uc_view?pv_ocorrencia_id=483610" title="DCM">DCM</a></td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Ano letivo:</td>
+                    <td>2021/2022</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Época:</td>
+                    <td>Exames ao abrigo de estatutos especiais - Mini-testes (2ºS)</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Data:</td>
+                    <td>2022-05-16</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Hora Início:</td>
+                    <td>14:30</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Duração:</td>
+                    <td>02:00</td>
+                </tr>
+
+                <tr>
+                    <td class="formulario-legenda">Salas:</td>
+                    <td>
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73280"
+                            title="B227 (Abre numa nova janela)"
+                            target="_blank"
+                            >B227</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73298"
+                            title="B231 (Abre numa nova janela)"
+                            target="_blank"
+                            >B231</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73304"
+                            title="B338 (Abre numa nova janela)"
+                            target="_blank"
+                            >B338</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73163"
+                            title="B215 (Abre numa nova janela)"
+                            target="_blank"
+                            >B215</a
+                        >
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <!-- end conteudoinner-->
+</div>

--- a/src/test/pages/single_exam/normal.html
+++ b/src/test/pages/single_exam/normal.html
@@ -1,0 +1,140 @@
+<div id="conteudo">
+    <div id="conteudoinner">
+        <h1 id="seccao"></h1>
+        <a name="ancora-conteudo" class="ecra"></a>
+        <h1>Exame de SO - Sistemas Operativos (L.EIC015) - 2S</h1>
+        <table>
+            <tbody>
+                <tr>
+                    <td class="formulario-legenda">Código:</td>
+                    <td><a href="ucurr_geral.ficha_uc_view?pv_ocorrencia_id=484378" title="SO">SO</a></td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Ano letivo:</td>
+                    <td>2021/2022</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Época:</td>
+                    <td>Exames ao abrigo de estatutos especiais - Mini-testes (2ºS)</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Data:</td>
+                    <td>2022-05-11</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Hora Início:</td>
+                    <td>17:30</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Duração:</td>
+                    <td>02:00</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Salas:</td>
+                    <td>
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73471"
+                            title="B104 (Abre numa nova janela)"
+                            target="_blank"
+                            >B104</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73398"
+                            title="B208 (Abre numa nova janela)"
+                            target="_blank"
+                            >B208</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73438"
+                            title="B213 (Abre numa nova janela)"
+                            target="_blank"
+                            >B213</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73470"
+                            title="B105 (Abre numa nova janela)"
+                            target="_blank"
+                            >B105</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73444"
+                            title="B103 (Abre numa nova janela)"
+                            target="_blank"
+                            >B103</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73445"
+                            title="B102 (Abre numa nova janela)"
+                            target="_blank"
+                            >B102</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73395"
+                            title="B308 (Abre numa nova janela)"
+                            target="_blank"
+                            >B308</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73396"
+                            title="B307 (Abre numa nova janela)"
+                            target="_blank"
+                            >B307</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73390"
+                            title="B305 (Abre numa nova janela)"
+                            target="_blank"
+                            >B305</a
+                        >,
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73408"
+                            title="B304 (Abre numa nova janela)"
+                            target="_blank"
+                            >B304</a
+                        >
+                    </td>
+                </tr>
+
+                <tr>
+                    <td class="formulario-legenda">Vigilantes:</td>
+                    <td>
+                        <a
+                            href="func_geral.formview?p_codigo=209847"
+                            title="Rui Carlos Camacho de Sousa Ferreira da Silva"
+                            >Rui Carlos Camacho de Sousa Ferreira da Silva</a
+                        ><br /><a
+                            href="func_geral.formview?p_codigo=672712"
+                            title="Pedro Nuno Ferreira da Rosa da Cruz Diniz"
+                            >Pedro Nuno Ferreira da Rosa da Cruz Diniz</a
+                        ><br /><a href="func_geral.formview?p_codigo=211669" title="Luís Paulo Gonçalves dos Reis"
+                            >Luís Paulo Gonçalves dos Reis</a
+                        ><br /><a
+                            href="func_geral.formview?p_codigo=451878"
+                            title="Luís Filipe Pinto de Almeida Teixeira"
+                            >Luís Filipe Pinto de Almeida Teixeira</a
+                        ><br /><a href="func_geral.formview?p_codigo=632556" title="Fábio Daniel Reis Gaspar"
+                            >Fábio Daniel Reis Gaspar</a
+                        ><br /><a href="func_geral.formview?p_codigo=209810" title="José Manuel de Magalhães Cruz"
+                            >José Manuel de Magalhães Cruz</a
+                        ><br /><a href="func_geral.formview?p_codigo=203540" title="Luís Miguel Barros Lopes"
+                            >Luís Miguel Barros Lopes</a
+                        ><br /><a href="func_geral.formview?p_codigo=588465" title="João Pedro Matos Teixeira Dias"
+                            >João Pedro Matos Teixeira Dias</a
+                        ><br /><a
+                            href="func_geral.formview?p_codigo=625975"
+                            title="André Nuno de Pinho Tavares Gurgo e Cirne"
+                            >André Nuno de Pinho Tavares Gurgo e Cirne</a
+                        ><br /><a href="func_geral.formview?p_codigo=666857" title="Carlos Miguel Ferraz Baquero-Moreno"
+                            >Carlos Miguel Ferraz Baquero-Moreno</a
+                        ><br /><a
+                            href="func_geral.formview?p_codigo=238172"
+                            title="Pedro Alexandre Guimarães Lobo Ferreira Souto"
+                            >Pedro Alexandre Guimarães Lobo Ferreira Souto</a
+                        >
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <!-- end conteudoinner-->
+</div>

--- a/src/test/pages/single_exam/observations.html
+++ b/src/test/pages/single_exam/observations.html
@@ -1,0 +1,67 @@
+<div id="conteudo">
+    <div id="conteudoinner">
+        <h1 id="seccao"></h1>
+        <a name="ancora-conteudo" class="ecra"></a>
+        <h1>Exame de LBAW - Laboratório de Bases de Dados e Aplicações Web (L.EIC023) - 1S</h1>
+        <table>
+            <tbody>
+                <tr>
+                    <td class="formulario-legenda">Código:</td>
+                    <td><a href="ucurr_geral.ficha_uc_view?pv_ocorrencia_id=484433" title="LBAW">LBAW</a></td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Ano letivo:</td>
+                    <td>2021/2022</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Época:</td>
+                    <td>Exames ao abrigo de estatutos especiais - Port.Est.Especiais 1ºS</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Data:</td>
+                    <td>2022-05-16</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Hora Início:</td>
+                    <td>14:30</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Duração:</td>
+                    <td>03:00</td>
+                </tr>
+                <tr>
+                    <td class="formulario-legenda">Observações:</td>
+                    <td>Sala de Pcs- 1ª parte da avaliação</td>
+                </tr>
+
+                <tr>
+                    <td class="formulario-legenda">Salas:</td>
+                    <td>
+                        <a
+                            href="instal_geral.espaco_view?pv_id=73431"
+                            title="B302 (Abre numa nova janela)"
+                            target="_blank"
+                            >B302</a
+                        >
+                    </td>
+                </tr>
+
+                <tr>
+                    <td class="formulario-legenda">Vigilantes:</td>
+                    <td>
+                        <a href="func_geral.formview?p_codigo=479881" title="Tiago Boldt Pereira de Sousa"
+                            >Tiago Boldt Pereira de Sousa</a
+                        ><br /><a href="func_geral.formview?p_codigo=598256" title="Fernando José Cassola Marques"
+                            >Fernando José Cassola Marques</a
+                        ><br /><a href="func_geral.formview?p_codigo=310021" title="Sérgio Sobral Nunes"
+                            >Sérgio Sobral Nunes</a
+                        ><br /><a href="func_geral.formview?p_codigo=246574" title="Pedro Miguel Alves Brandão"
+                            >Pedro Miguel Alves Brandão</a
+                        >
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <!-- end conteudoinner-->
+</div>

--- a/src/tests.html
+++ b/src/tests.html
@@ -43,6 +43,7 @@
     <script src="js/extractors/bills.js"></script>
     <script src="js/extractors/bills_payment_refs.js"></script>
     <script src="js/extractors/reservations.js"></script>
+    <script src="js/extractors/single_exam.js"></script>
 
     <!-- Test files -->
     <script src="test/extractors/timetable.js"></script>
@@ -51,6 +52,7 @@
     <script src="test/extractors/datatable.js"></script>
     <script src="test/extractors/extractor.js"></script>
     <script src="test/extractors/reservations.js"></script>
+    <script src="test/extractors/single_exam.js"></script>
 
     <script>
         mocha.checkLeaks();


### PR DESCRIPTION
# Changes

- The extractor now extends `EventExtractor` (#116)
- Fix the parsing, as the table is not fixed. I.e., there are optional parameters, therefore parsing rows by indexes is not the ideal approach. The new approach is searching by label/legend to find the correct row.
- Fix parsing for the type of exam (Recurso, Mini Teste, ...)